### PR TITLE
halium: Include libui_compat_layer

### DIFF
--- a/halium.mk
+++ b/halium.mk
@@ -349,6 +349,7 @@ PRODUCT_PACKAGES += \
     libcamera_compat_layer \
     libdroidmedia \
     libhwc2_compat_layer \
+    libui_compat_layer \
     libmedia_compat_layer \
     libselinux_stubs \
     libubuntu_application_api \


### PR DESCRIPTION
Various projects can benefit from the use of libui_compat_layer, the GraphicBuffer wrapper in libhybris.
Most notable examples are haliumqsgcontext & qtubuntu-camera:

- https://github.com/Halium/haliumqsgcontext
- https://gitlab.com/ubports/development/core/qtubuntu-camera/-/merge_requests/24