### PR TITLE
halium: include libdroidmedia

### DIFF
--- a/halium.mk
+++ b/halium.mk
@@ -323,3 +323,4 @@ PRODUCT_PACKAGES += \
     micshm.sh \
     miniafservice \
     minimediaservice \
+    libdroidmedia \


### PR DESCRIPTION
droidmedia seems to be included in the manifest but not added into the image for H10. it is available on other images so it should not break any functionality.