### PR TITLE
(H13) halium.mk: include cacerts

### DIFF
--- a/halium.mk
+++ b/halium.mk
@@ -34,6 +34,7 @@ PRODUCT_PACKAGES += \
     bpfloader \
     bugreport \
     bugreportz \
+    cacerts \
     cgroups.json \
     charger \
     cmd \


### PR DESCRIPTION
These are required to properly deal with SSL in any form inside the Android container.