### PR TITLE
(H10) halium.mk: include cacerts

### DIFF
--- a/halium.mk
+++ b/halium.mk
@@ -36,6 +36,7 @@ PRODUCT_PACKAGES += \
     bpfloader \
     bugreport \
     bugreportz \
+    cacerts \
     cgroups.json \
     charger \
     cmd \


### PR DESCRIPTION
These are required to properly deal with SSL in any form inside the Android container.

Backport of https://github.com/Halium/android_vendor_halium_config/pull/6